### PR TITLE
fix: implement router performance issue

### DIFF
--- a/leetcode/leetcode_3508_implement_router/solution.py
+++ b/leetcode/leetcode_3508_implement_router/solution.py
@@ -1,47 +1,46 @@
+import bisect
 from typing import List
-
-SRC = 0
-DEST = 1
-TIME = 2
 
 
 class Router:
     def __init__(self, memoryLimit: int):
         self.packets = []
+        self.seen = set()
+        self.destination_to_time_stamps = {}
         self.limit = memoryLimit
 
     def addPacket(self, source: int, destination: int, timestamp: int) -> bool:
         # Check for duplicate
-        incoming_packet = [source, destination, timestamp]
-        if incoming_packet in self.packets:
+        packet = (source, destination, timestamp)
+        if packet in self.seen:
             return False
 
         # If at limit, remove oldest packet
         if len(self.packets) == self.limit:
-            oldest_position = 0
-            oldest_packet = self.packets[oldest_position]
-
-            for i, packet in enumerate(self.packets):
-                if packet[TIME] < oldest_packet[TIME]:
-                    oldest_packet = packet
-                    oldest_position = i
-
-            self.packets.pop(oldest_position)
+            self.forwardPacket()
 
         # Add the packet
-        self.packets.append(incoming_packet)
+        self.packets.append(packet)
+        self.seen.add(packet)
+        time_stamps = self.destination_to_time_stamps.setdefault(destination, [])
+        bisect.insort(time_stamps, timestamp)
         return True
 
     def forwardPacket(self) -> List[int]:
-        if self.packets:
-            return self.packets.pop(0)
-        return []
+        if not self.packets:
+            return []
+
+        packet = source, destination, timestamp = self.packets.pop(0)
+        self.seen.remove(packet)
+        self.destination_to_time_stamps[destination].remove(timestamp)
+
+        return [source, destination, timestamp]
 
     def getCount(self, destination: int, startTime: int, endTime: int) -> int:
-        return sum(
-            int(packet[DEST] == destination and startTime <= packet[TIME] <= endTime)
-            for packet in self.packets
-        )
+        time_stamps = self.destination_to_time_stamps.get(destination, [])
+        start_index = bisect.bisect_left(time_stamps, startTime)
+        end_index = bisect.bisect_right(time_stamps, endTime)
+        return end_index - start_index
 
 
 # Your Router object will be instantiated and called as such:

--- a/leetcode/leetcode_3508_implement_router/test_solution.py
+++ b/leetcode/leetcode_3508_implement_router/test_solution.py
@@ -48,6 +48,14 @@ from solution import Router
             ),
             id="Example 2",
         ),
+        pytest.param(
+            types.SimpleNamespace(
+                actions=["Router", "addPacket", "getCount"],
+                args_list=[[3], [1, 4, 90], [5, 100, 110]],
+                expected=[None, True, 0],
+            ),
+            id="key error",
+        ),
     ],
 )
 def test_solution(test_case):


### PR DESCRIPTION
For very large transactions, searching a linear list does not cut it. We need to use set and dictionary for faster look up.